### PR TITLE
Add Gradio interface and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,54 @@ The system includes Flower for monitoring Celery tasks:
 - Consider implementing API authentication for the Gateway service
 - Regularly update dependencies to address security vulnerabilities
 
+
+## 🎛️ Local Gradio Interface
+
+This repository includes an optional Gradio-based client for interacting with the Gateway API.
+
+### Prerequisites
+
+Install Gradio and Requests in your Python environment:
+
+```bash
+pip install gradio requests
+```
+
+### Running the Interface
+
+Launch the UI by running:
+
+```bash
+python gradio_interface.py
+```
+
+The interface allows you to send requests to the Gateway service running on `http://localhost:8000` by default. Set the `GATEWAY_URL` environment variable to target a different gateway instance.
+
+### Usage Examples
+
+**Upload a PDF**
+1. Select the *Upload PDF* tab.
+2. Choose a PDF file and fill in the publication information.
+3. Click **Submit PDF**. The response contains a `task_id` you can query via `/tasks/{task_id}`.
+
+**Process Images**
+1. Open the *Direct Images* tab.
+2. Enter the path to the directory containing images on the gateway host.
+3. Click **Submit Images** to queue the `/process/direct_images` task.
+
+**Send Raw JSON**
+1. Use the *Raw JSON* tab to paste article text.
+2. Press **Submit JSON** to call `/process/digital_raw_json`.
+
+### Modifying Prompts
+
+Prompt templates used for article analysis live in `ocr_engine/config_newPrompt.py`. Edit the `*_SYSTEM_INSTRUCTION` strings to customize Gemini behavior and restart the OCR workers for changes to take effect.
+
+## ➕ New API Endpoints
+
+Alongside existing routes, the Gateway now exposes:
+
+- **POST /process/direct_images** – queue OCR processing for a local image directory. Returns `{ "message": str, "task_id": str }`.
+- **POST /process/digital_raw_json** – analyze article content sent directly as JSON. Returns `{ "message": str, "task_id": str }`.
+
+These complement `/pipeline`, `/crawl/newspaper_pdf`, and `/process/digital_s3_json`. Retrieve task progress via `GET /tasks/{task_id}` which reports the Celery state and results.

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -1,0 +1,115 @@
+import os
+import json
+import requests
+import gradio as gr
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8000")
+
+
+def submit_pdf(pdf_file, publication, edition, language, zone, date, dpi, quality, resize_bool, base_url):
+    url = base_url.rstrip('/') + '/pipeline'
+    files = {"pdf": (os.path.basename(pdf_file.name), pdf_file, "application/pdf")}
+    data = {
+        "publicationName": publication,
+        "editionName": edition,
+        "languageName": language,
+        "zoneName": zone,
+        "date": date,
+        "dpi": int(dpi),
+        "quality": int(quality),
+        "resize_bool": resize_bool,
+    }
+    resp = requests.post(url, data=data, files=files)
+    try:
+        return json.dumps(resp.json(), indent=2)
+    except Exception:
+        return f"Error {resp.status_code}: {resp.text}"
+
+
+def submit_direct_images(image_dir, publication, edition, language, zone, date, base_url):
+    url = base_url.rstrip('/') + '/process/direct_images'
+    payload = {
+        "imageDirectory": image_dir,
+        "publicationName": publication,
+        "editionName": edition,
+        "languageName": language,
+        "zoneName": zone,
+        "date": date,
+    }
+    resp = requests.post(url, json=payload)
+    try:
+        return json.dumps(resp.json(), indent=2)
+    except Exception:
+        return f"Error {resp.status_code}: {resp.text}"
+
+
+def submit_raw_json(title, content, base_url):
+    url = base_url.rstrip('/') + '/process/digital_raw_json'
+    payload = {
+        "title": title,
+        "content": content,
+    }
+    resp = requests.post(url, json=payload)
+    try:
+        return json.dumps(resp.json(), indent=2)
+    except Exception:
+        return f"Error {resp.status_code}: {resp.text}"
+
+
+def build_interface():
+    base_url_box = gr.Textbox(value=GATEWAY_URL, label="Gateway URL")
+
+    with gr.Tab("Upload PDF"):
+        pdf_file = gr.File(label="PDF File")
+        publication = gr.Textbox(label="Publication Name")
+        edition = gr.Textbox(label="Edition Name", value="")
+        language = gr.Textbox(label="Language Name")
+        zone = gr.Textbox(label="Zone Name")
+        date = gr.Textbox(label="Date (dd-mm-yyyy)")
+        dpi = gr.Number(value=200, label="DPI")
+        quality = gr.Number(value=85, label="JPEG Quality")
+        resize = gr.Checkbox(value=True, label="Resize Images")
+        pdf_output = gr.Textbox(label="Response")
+        pdf_btn = gr.Button("Submit PDF")
+        pdf_btn.click(
+            submit_pdf,
+            [pdf_file, publication, edition, language, zone, date, dpi, quality, resize, base_url_box],
+            pdf_output,
+        )
+
+    with gr.Tab("Direct Images"):
+        img_dir = gr.Textbox(label="Image Directory Path")
+        publication_i = gr.Textbox(label="Publication Name")
+        edition_i = gr.Textbox(label="Edition Name", value="")
+        language_i = gr.Textbox(label="Language Name")
+        zone_i = gr.Textbox(label="Zone Name")
+        date_i = gr.Textbox(label="Date (dd-mm-yyyy)")
+        img_output = gr.Textbox(label="Response")
+        img_btn = gr.Button("Submit Images")
+        img_btn.click(
+            submit_direct_images,
+            [img_dir, publication_i, edition_i, language_i, zone_i, date_i, base_url_box],
+            img_output,
+        )
+
+    with gr.Tab("Raw JSON"):
+        title_j = gr.Textbox(label="Title")
+        content_j = gr.Textbox(label="Content", lines=10)
+        json_output = gr.Textbox(label="Response")
+        json_btn = gr.Button("Submit JSON")
+        json_btn.click(
+            submit_raw_json,
+            [title_j, content_j, base_url_box],
+            json_output,
+        )
+
+
+def main():
+    with gr.Blocks(title="Gateway Client") as demo:
+        gr.Markdown("# Gradio Gateway Client")
+        build_interface()
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `gradio_interface.py` for submitting PDFs, images, and JSON to the gateway
- document how to install prerequisites and run the Gradio UI
- add examples for uploading PDFs, images, and modifying prompts
- mention new `/process/direct_images` and `/process/digital_raw_json` endpoints

## Testing
- `pytest -q`
- `python -m py_compile gradio_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_68558a499a688325b2fd8997b685c9bf