### PR TITLE
Remove duplicate zoneName in NodeJsPayload

### DIFF
--- a/ocr_engine/models.py
+++ b/ocr_engine/models.py
@@ -28,7 +28,6 @@ class NodeJsPayload(BaseModel):
     zoneName: Optional[str] = ""
     language: str
     date: str
-    zoneName: Optional[str] = None
     newsId: Optional[str] = None
     articles: List[Dict[str, Any]]
 


### PR DESCRIPTION
## Summary
- clean up `NodeJsPayload` by keeping a single `zoneName` field with empty string default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558a2db08c832599522b5f99e66548