### PR TITLE
Add single image processing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ The production configuration uses pre-built images and includes Docker Swarm set
   - Process digital article from S3 JSON
   - Parameters: `s3_url`, `site_name`, `timestamp`, `mediaId`
 
+- **POST /process/single_image**
+  - Process a single newspaper page image
+  - Parameters: `image`, `publicationName`, `editionName`, `languageName`, `zoneName`, `date`, `pageNumber`
+
 - **GET /tasks/{task_id}**
   - Check status of a processing task
   - Returns task state and results


### PR DESCRIPTION
## Summary
- implement /process/single_image endpoint in gateway
- add corresponding Celery task `process_single_image`
- document the new endpoint

## Testing
- `python -m py_compile gateway/main.py ocr_engine/tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558a3b7be08325b533ad45d86c9eee