### PR TITLE
Add Gemini prompt update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ The production configuration uses pre-built images and includes Docker Swarm set
 - **GET /tasks/{task_id}**
   - Check status of a processing task
   - Returns task state and results
+- **POST /admin/update_prompt**
+  - Update the Gemini content analysis prompt (requires `X-Admin-Token` header)
+  - Body: `{ "prompt": "new system instruction" }`
+
+### Updating the Prompt
+
+Use the `/admin/update_prompt` endpoint to change the system instruction used by the OCR engine workers.
+
+Example:
+
+```bash
+curl -X POST http://localhost:8000/admin/update_prompt \
+     -H "X-Admin-Token: <your_token>" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt": "You are a journalist..."}'
+```
 
 ## 🔧 Configuration
 
@@ -219,4 +235,5 @@ The system includes Flower for monitoring Celery tasks:
 - S3 bucket permissions should be properly configured
 - Consider implementing API authentication for the Gateway service
 - Regularly update dependencies to address security vulnerabilities
+- Set the `ADMIN_TOKEN` environment variable to secure admin endpoints like `/admin/update_prompt`
 

--- a/ocr_engine/config.py
+++ b/ocr_engine/config.py
@@ -727,6 +727,28 @@ def get_configured_digital_text_analyzer_model(): # NEW getter
     if not digital_text_analyzer_model_instance: print(f"Process {os.getpid()}: Digital text analyzer model accessed but is None.")
     return digital_text_analyzer_model_instance
 
+# --- Dynamic Prompt Update ---
+def update_content_analysis_system_instruction(new_instruction: str) -> bool:
+    """Update the system prompt for content analysis and reinitialize the model."""
+    global CONTENT_ANALYSIS_SYSTEM_INSTRUCTION, content_analyzer_model_instance
+    CONTENT_ANALYSIS_SYSTEM_INSTRUCTION = new_instruction
+    try:
+        if PROCESS_SPECIFIC_GEMINI_KEY:
+            content_analyzer_model_instance = genai.GenerativeModel(
+                model_name=CONTENT_ANALYSIS_MODEL_NAME,
+                generation_config=CONTENT_ANALYSIS_GENERATION_CONFIG,
+                system_instruction=CONTENT_ANALYSIS_SYSTEM_INSTRUCTION,
+            )
+            print(f"Process {os.getpid()}: Content analysis prompt updated and model reinitialized.")
+            return True
+        else:
+            print(f"Process {os.getpid()}: Gemini key not configured; cannot reinitialize model.")
+            return False
+    except Exception as e:
+        print(f"Process {os.getpid()}: Failed to update prompt: {e}")
+        content_analyzer_model_instance = None
+        return False
+
 # --- AWS S3 Client ---
 AWS_S3_BUCKET_NAME_CONFIG = os.getenv('AWS_S3_BUCKET_NAME')
 AWS_REGION_CONFIG = os.getenv('AWS_S3_REGION', 'ap-south-1')


### PR DESCRIPTION
## Summary
- add ADMIN_TOKEN-protected endpoint in Gateway to update the Gemini prompt
- expose `update_content_analysis_system_instruction` in ocr_engine config
- add Celery task to propagate prompt change to workers
- document the new `/admin/update_prompt` API and environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558a435d308325a2912d61182728d8