### PR TITLE
Add gradio compose service

### DIFF
--- a/Dockerfile.gradio
+++ b/Dockerfile.gradio
@@ -1,0 +1,15 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY gateway/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
+    pip install --no-cache-dir gradio requests
+
+# Copy interface script
+COPY scripts/gradio_interface.py /app/gradio_interface.py
+
+EXPOSE 7860
+
+CMD ["python", "gradio_interface.py"]

--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ Launch the UI by running:
 python gradio_interface.py
 ```
 
+You can also run the entire stack (gateway, OCR engine, Redis and the Gradio UI)
+using Docker Compose:
+
+```bash
+docker compose -f docker-compose.epaper-test.yml up --build
+```
+
 The interface allows you to send requests to the Gateway service running on `http://localhost:8000` by default. Set the `GATEWAY_URL` environment variable to target a different gateway instance.
 
 ### Usage Examples
@@ -300,6 +307,13 @@ Install the dependencies and launch the interface:
 ```bash
 pip install gradio requests
 python scripts/gradio_interface.py
+```
+
+Alternatively you can spin up the entire stack using Docker Compose which also
+runs the Gradio container:
+
+```bash
+docker compose -f docker-compose.epaper-test.yml up --build
 ```
 
 The interface exposes three tabs:

--- a/docker-compose.epaper-test.yml
+++ b/docker-compose.epaper-test.yml
@@ -22,6 +22,20 @@ services:
     command: uvicorn main:app --host 0.0.0.0 --port 5001 --reload
     restart: unless-stopped
 
+  gradio_ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.gradio
+    env_file: .env
+    environment:
+      - GATEWAY_BASE_URL=http://gateway:5001
+    ports:
+      - "7860:7860"
+    volumes:
+      - ./scripts/gradio_interface.py:/app/gradio_interface.py:ro
+    depends_on:
+      - gateway
+
   ocr_engine_worker:
     build:
       context: ./ocr_engine


### PR DESCRIPTION
## Summary
- add Dockerfile.gradio for running gradio interface
- add gradio_ui service to docker-compose.epaper-test.yml
- document docker compose usage for running the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855890831a88325afb1a4150c25310a